### PR TITLE
fixed btoa Uncaught InvalidCharacterError

### DIFF
--- a/editor.js
+++ b/editor.js
@@ -212,7 +212,7 @@ function pngdata () {
     'use strict';
     var svgdata, img, canvas, context;
 
-    svgdata = 'data:image/svg+xml;base64,' + btoa(ssvg());
+    svgdata = 'data:image/svg+xml;base64,' + btoa(unescape(encodeURIComponent(ssvg())));
     img = new Image();
     img.src = svgdata;
     canvas = document.createElement('canvas');


### PR DESCRIPTION
Fixed error.
If source file has utf-8 encoding and contains cyrillic chars:
```
$ nw wavedrom-editor-v0.9.13.nw source 1.json png 1.png
[4835:0209/145448:INFO:CONSOLE(1)] ""process.mainModule.filename: /tmp/.org.chromium.Chromium.DmDUtz/editor.html"", source: process_main (1)
[4835:0209/145448:INFO:CONSOLE(215)] "Uncaught InvalidCharacterError: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.", source: file:///tmp/.org.chromium.Chromium.DmDUtz/editor.js (215)
```