### PR TITLE
bugfix: add skins/narrower.js narrowerer.js to editor.html

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -16,6 +16,8 @@
         <script src="skins/default.js"></script>
         <script src="skins/dark.js"></script>
         <script src="skins/narrow.js"></script>
+        <script src="skins/narrower.js"></script>
+        <script src="skins/narrowerer.js"></script>
         <script src="skins/lowkey.js"></script>
         <script src="wavedrom.min.js"></script>
         <script src="editor.js"></script>


### PR DESCRIPTION
fix #96 
Fixed result:
![image](https://github.com/wavedrom/wavedrom.github.io/assets/32255131/d4fb06ff-3582-4d5c-9693-fc697cfffa89)
